### PR TITLE
Ramp up load test

### DIFF
--- a/load-testing/src/test/resources/test.conf
+++ b/load-testing/src/test/resources/test.conf
@@ -12,4 +12,14 @@ shopping-cart-load-test {
 
   users-per-second = 1
   users-per-second = ${?USERS_PER_SECOND}
+
+  ramp-from = 10
+  ramp-from = ${?RAMP_FROM}
+
+  ramp-to = 50
+  ramp-to = ${?RAMP_TO}
+
+  ramp-over = 10 minutes
+  ramp-over = ${?RAMP_OVER}
+
 }

--- a/load-testing/src/test/scala/com/lightbend/akka/samples/load/ShoppingCartServiceLoadTest.scala
+++ b/load-testing/src/test/scala/com/lightbend/akka/samples/load/ShoppingCartServiceLoadTest.scala
@@ -22,13 +22,19 @@ class ShoppingCartServiceLoadTest extends Simulation {
       ShoppingCartScenario(grpcTarget, randomPayloadSize)
     )
 
-  private val users = System.getProperty("requestsPerSecond", "1").toInt  // # of users
+  private val users =  testConfig.usersPerSecond
+
+  private val rampFrom = testConfig.rampFrom
+  private val rampTo = testConfig.rampTo
 
   private val loadDuration: FiniteDuration = (1 * 60).seconds // test duration in seconds
 
   println(s"Starting Shopping cart load test at ${users} users per second")
 
-  val testPlan = tests.flatMap(_.all.map(_.inject(constantUsersPerSec(users).during(loadDuration))))
+  val testPlan = tests.flatMap(_.all.map(_.inject(
+    constantUsersPerSec(users).during(loadDuration),
+    rampUsersPerSec(rampFrom).to(rampTo).during(testConfig.rampOver)
+  )))
   //val testPlan = tests.flatMap(_.all.map(_.inject(atOnceUsers(users))))
   setUp(
     testPlan

--- a/load-testing/src/test/scala/com/lightbend/akka/samples/load/TestConfig.scala
+++ b/load-testing/src/test/scala/com/lightbend/akka/samples/load/TestConfig.scala
@@ -10,7 +10,10 @@ case class TestConfig(
   targetHost: String,
   targetPort: Int,
   testDuration: FiniteDuration,
-  usersPerSecond: Int)
+  usersPerSecond: Int,
+  rampFrom: Int,
+  rampTo: Int,
+  rampOver: FiniteDuration)
 
 object TestConfig {
   implicit val reader = deriveReader[TestConfig]

--- a/shopping-cart-service/deployment/resources.yaml
+++ b/shopping-cart-service/deployment/resources.yaml
@@ -43,8 +43,8 @@ spec:
                 -Dconfig.resource=deployed.conf
                 -XX:+UseG1GC
                 -XX:+UseStringDeduplication
-                -Xmx1000m
-                -Xms1000m
+                -Xmx1500m
+                -Xms1500m
                 -XX:+PrintFlagsFinal
             # this value should stay the same as number of replicas
             - name: REQUIRED_CONTACT_POINT_NR

--- a/shopping-cart-service/src/main/resources/cluster.conf
+++ b/shopping-cart-service/src/main/resources/cluster.conf
@@ -12,6 +12,8 @@ akka {
 
     sharding {
       least-shard-allocation-strategy.rebalance-absolute-limit = 20
+      passivation.strategy = "default-strategy"
+      passivation.default-strategy.active-entity-limit = 200000
     }
   }
 }


### PR DESCRIPTION
Some tweaks to the load test to allow a ramp up on load.

Also some safeguards on the shopping cart service to avoid blowing the heap, setting passivation strategy to max active entity strategy, max active entities up to 250k on a 1.5gb heap.  